### PR TITLE
Use Gemini for NL to DSL translation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,12 @@
 """FastAPI application for interacting with Elasticsearch."""
 import base64
 import io
+import json
 import os
 from copy import deepcopy
 from typing import Any, Optional
 
+import google.generativeai as genai
 import matplotlib.pyplot as plt
 from elasticsearch import Elasticsearch
 from fastapi import FastAPI
@@ -14,6 +16,8 @@ from pydantic import BaseModel
 ES_HOST_ENV = "ES_HOST"
 ES_USER_ENV = "ES_USER"
 ES_PASS_ENV = "ES_PASS"
+GEMINI_API_KEY_ENV = "GEMINI_API_KEY"
+GEMINI_MODEL_ENV = "GEMINI_MODEL"
 
 
 def _load_env_variable(name: str) -> Optional[str]:
@@ -36,6 +40,11 @@ def _load_env_variable(name: str) -> Optional[str]:
 ES_HOST = _load_env_variable(ES_HOST_ENV)
 ES_USER = _load_env_variable(ES_USER_ENV)
 ES_PASS = _load_env_variable(ES_PASS_ENV)
+GEMINI_API_KEY = _load_env_variable(GEMINI_API_KEY_ENV)
+GEMINI_MODEL = _load_env_variable(GEMINI_MODEL_ENV) or "gemini-1.5-flash"
+
+if GEMINI_API_KEY:
+    genai.configure(api_key=GEMINI_API_KEY)
 
 # Initialize Elasticsearch client using the loaded credentials.
 # The client is ready for future enhancements that may require Elasticsearch operations.
@@ -92,6 +101,303 @@ _TIMEFRAME_RULES: tuple[TimeframeRule, ...] = (
         "Restricted results to the previous day because the query mentioned yesterday.",
     ),
 )
+
+
+async def _load_index_mapping(index: str) -> dict[str, Any]:
+    """Fetch the index mapping for validation and prompting."""
+
+    if ES_CLIENT is None:
+        return {}
+
+    try:
+        return await run_in_threadpool(ES_CLIENT.indices.get_mapping, index=index)
+    except Exception:  # noqa: BLE001 - validation should not break the flow
+        return {}
+
+
+def _format_mapping_snippet(mapping: dict[str, Any], max_chars: int = 2500) -> str:
+    """Return a truncated JSON representation of the mapping for prompts."""
+
+    if not mapping:
+        return "Mapping unavailable."
+
+    snippet_source: dict[str, Any] = {}
+    for index_name, index_data in mapping.items():
+        properties = index_data.get("mappings", {}).get("properties") or {}
+        snippet_source[index_name] = properties
+        break
+
+    snippet = json.dumps(snippet_source, indent=2, sort_keys=True)
+    if len(snippet) > max_chars:
+        return f"{snippet[: max_chars - 3]}..."
+    return snippet
+
+
+def _collect_mapping_fields(mapping: dict[str, Any]) -> set[str]:
+    """Flatten Elasticsearch mapping into a set of dot-notated field names."""
+
+    fields: set[str] = set()
+
+    def _walk(properties: dict[str, Any], prefix: str = "") -> None:
+        for field_name, definition in properties.items():
+            full_name = f"{prefix}.{field_name}" if prefix else field_name
+            fields.add(full_name)
+
+            if isinstance(definition, dict):
+                sub_fields = definition.get("fields", {})
+                if isinstance(sub_fields, dict):
+                    for sub_name in sub_fields:
+                        fields.add(f"{full_name}.{sub_name}")
+
+                nested_properties = definition.get("properties")
+                if isinstance(nested_properties, dict):
+                    _walk(nested_properties, full_name)
+
+    for index_data in mapping.values():
+        properties = index_data.get("mappings", {}).get("properties")
+        if isinstance(properties, dict):
+            _walk(properties)
+
+    return fields
+
+
+def _extract_fields_from_dsl(obj: Any) -> set[str]:
+    """Recursively collect field names referenced in a DSL structure."""
+
+    fields: set[str] = set()
+
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            if key in {"term", "match", "match_phrase", "match_phrase_prefix", "wildcard", "regexp", "prefix"}:
+                if isinstance(value, dict):
+                    for field_name, field_value in value.items():
+                        fields.add(field_name)
+                        fields.update(_extract_fields_from_dsl(field_value))
+                continue
+
+            if key in {"range", "fuzzy"}:
+                if isinstance(value, dict):
+                    for field_name, field_value in value.items():
+                        fields.add(field_name)
+                        fields.update(_extract_fields_from_dsl(field_value))
+                continue
+
+            if key == "exists":
+                if isinstance(value, dict):
+                    field_name = value.get("field")
+                    if isinstance(field_name, str):
+                        fields.add(field_name)
+                continue
+
+            if key == "multi_match" and isinstance(value, dict):
+                possible_fields = value.get("fields")
+                if isinstance(possible_fields, list):
+                    for candidate in possible_fields:
+                        if isinstance(candidate, str):
+                            fields.add(candidate.split("^")[0])
+                default_field = value.get("default_field")
+                if isinstance(default_field, str):
+                    fields.add(default_field)
+                fields.update(_extract_fields_from_dsl(value))
+                continue
+
+            if key == "query_string" and isinstance(value, dict):
+                qs_fields = value.get("fields")
+                if isinstance(qs_fields, list):
+                    for candidate in qs_fields:
+                        if isinstance(candidate, str):
+                            fields.add(candidate.split("^")[0])
+                default_field = value.get("default_field")
+                if isinstance(default_field, str):
+                    fields.add(default_field)
+                fields.update(_extract_fields_from_dsl(value))
+                continue
+
+            if key == "sort":
+                if isinstance(value, list):
+                    for sort_entry in value:
+                        if isinstance(sort_entry, dict):
+                            for field_name, sort_value in sort_entry.items():
+                                if isinstance(field_name, str) and field_name != "_score":
+                                    fields.add(field_name)
+                                fields.update(_extract_fields_from_dsl(sort_value))
+                elif isinstance(value, dict):
+                    for field_name, sort_value in value.items():
+                        if isinstance(field_name, str) and field_name != "_score":
+                            fields.add(field_name)
+                        fields.update(_extract_fields_from_dsl(sort_value))
+                continue
+
+            if key in {"aggs", "aggregations"}:
+                fields.update(_extract_fields_from_dsl(value))
+                continue
+
+            if key == "field" and isinstance(value, str):
+                fields.add(value)
+                continue
+
+            if key in {"fields", "docvalue_fields"} and isinstance(value, list):
+                for candidate in value:
+                    if isinstance(candidate, str):
+                        fields.add(candidate.split("^")[0])
+                continue
+
+            fields.update(_extract_fields_from_dsl(value))
+
+    elif isinstance(obj, list):
+        for item in obj:
+            fields.update(_extract_fields_from_dsl(item))
+
+    return fields
+
+
+def _validate_dsl_fields(dsl: dict[str, Any], mapping_fields: set[str]) -> set[str]:
+    """Return the set of fields referenced in DSL that are absent in the mapping."""
+
+    if not mapping_fields:
+        return set()
+
+    referenced = _extract_fields_from_dsl(dsl)
+    return {field for field in referenced if field not in mapping_fields}
+
+
+def translate_with_gemini(
+    nl_text: str,
+    mapping: dict[str, Any],
+    prefer: str = "dsl",
+) -> tuple[dict[str, Any], str]:
+    """Translate natural language into Elasticsearch DSL using Gemini."""
+
+    if not GEMINI_API_KEY:
+        raise RuntimeError("GEMINI_API_KEY is not configured.")
+
+    mapping_snippet = _format_mapping_snippet(mapping)
+    example_translation = {
+        "index": "logs-*",
+        "size": 5,
+        "query": {
+            "bool": {
+                "filter": [
+                    {"term": {"event.action.keyword": "authentication_failure"}},
+                    {
+                        "range": {
+                            "@timestamp": {
+                                "gte": "now-1d/d",
+                                "lt": "now/d",
+                            }
+                        }
+                    },
+                ]
+            }
+        },
+    }
+
+    prompt = (
+        "You are an assistant that converts natural language security analytics requests "
+        "into Elasticsearch DSL queries. Act as a query generator.\n\n"
+        "Example translation:\n"
+        "NL: \"Show failed login attempts in the last 24 hours\"\n"
+        f"DSL:\n{json.dumps(example_translation, indent=2)}\n\n"
+        "Index mapping snippet for logs-*:\n"
+        f"{mapping_snippet}\n\n"
+        "Translate the following natural language request into Elasticsearch DSL. "
+        f"Prefer producing the {prefer}. Respond with JSON only using the keys "
+        '{"dsl": { ... }, "explain": "<text>"}. Do not wrap the response in markdown.'
+        "\nNL input: "
+        f"{nl_text}"
+    )
+
+    model = genai.GenerativeModel(
+        model_name=GEMINI_MODEL,
+        generation_config={"response_mime_type": "application/json"},
+    )
+
+    response = model.generate_content(prompt)
+    if not getattr(response, "text", None):
+        raise ValueError("Empty response from Gemini.")
+
+    try:
+        payload = json.loads(response.text)
+    except json.JSONDecodeError as exc:  # noqa: PERF203 - more informative error
+        raise ValueError("Gemini response was not valid JSON.") from exc
+
+    dsl = payload.get("dsl")
+    if not isinstance(dsl, dict):
+        raise ValueError("Gemini response missing 'dsl' object.")
+
+    explain_text = payload.get("explain", "")
+    if explain_text is None:
+        explain_text = ""
+
+    return dsl, str(explain_text)
+
+
+def _rule_based_translation(
+    session_data: dict[str, Any],
+    user_query: str,
+) -> tuple[Optional[dict[str, Any]], list[str]]:
+    """Attempt to translate using local rule-based heuristics."""
+
+    lowered_query = (user_query or "").lower()
+    explanations: list[str] = []
+
+    apply_vpn_filter = "now filter only vpn" in lowered_query
+
+    if apply_vpn_filter and session_data.get("last_dsl"):
+        search_params = deepcopy(session_data["last_dsl"])
+        query_clause = search_params.setdefault("query", {})
+        if isinstance(query_clause, dict) and "bool" in query_clause:
+            bool_query = query_clause["bool"]
+            must_clause = bool_query.get("must")
+            vpn_match = {"match": {"url.original": "vpn"}}
+            if isinstance(must_clause, list):
+                bool_query["must"] = [*must_clause, vpn_match]
+            elif must_clause is None:
+                bool_query["must"] = [vpn_match]
+            else:
+                bool_query["must"] = [must_clause, vpn_match]
+        else:
+            search_params["query"] = {"bool": {"must": [{"match": {"url.original": "vpn"}}]}}
+        explanations.append("Applied VPN filter on previous query.")
+        return search_params, explanations
+
+    if apply_vpn_filter and not session_data.get("last_dsl"):
+        explanations.append(
+            "No previous query found for this session; unable to apply VPN filter."
+        )
+
+    filters: list[dict[str, Any]] = []
+    matched_rule = False
+
+    if "failed login" in lowered_query or "suspicious login" in lowered_query:
+        filters.append({"term": {"event.action.keyword": "authentication_failure"}})
+        explanations.append(
+            "Applied authentication failure filter because the query mentioned failed or suspicious logins."
+        )
+        matched_rule = True
+
+    timeframe_filters, _, timeframe_explanation = _resolve_timeframe_filters(lowered_query)
+    if timeframe_filters:
+        filters.extend(timeframe_filters)
+        matched_rule = True
+        if timeframe_explanation:
+            explanations.append(timeframe_explanation)
+
+    if matched_rule:
+        if filters:
+            es_query: dict[str, Any] = {"bool": {"filter": filters}}
+        else:
+            es_query = {"match_all": {}}
+
+        search_params = {
+            "index": "logs-*",
+            "size": 5,
+            "sort": [{"@timestamp": {"order": "desc"}}],
+            "query": es_query,
+        }
+        return search_params, explanations
+
+    return None, explanations
 
 
 def _resolve_timeframe_filters(
@@ -207,58 +513,51 @@ async def ask(request: AskRequest) -> dict[str, Any]:
     session_data = SESSION_CONTEXT.setdefault(session_id, {})
 
     user_query = request.query or ""
-    lowered_query = user_query.lower()
 
-    filters: list[dict[str, Any]] = []
-    explanations: list[str] = []
+    mapping = await _load_index_mapping("logs-*")
 
-    apply_vpn_filter = "now filter only vpn" in lowered_query
+    search_params, explanations = _rule_based_translation(session_data, user_query)
 
-    if apply_vpn_filter and session_data.get("last_dsl"):
-        search_params = deepcopy(session_data["last_dsl"])
-        query_clause = search_params.setdefault("query", {})
-        if isinstance(query_clause, dict) and "bool" in query_clause:
-            bool_query = query_clause["bool"]
-            must_clause = bool_query.get("must")
-            vpn_match = {"match": {"url.original": "vpn"}}
-            if isinstance(must_clause, list):
-                bool_query["must"] = [*must_clause, vpn_match]
-            elif must_clause is None:
-                bool_query["must"] = [vpn_match]
-            else:
-                bool_query["must"] = [must_clause, vpn_match]
-        else:
-            search_params["query"] = {"bool": {"must": [{"match": {"url.original": "vpn"}}]}}
-        explanations.append("Applied VPN filter on previous query.")
-    else:
-        if apply_vpn_filter and not session_data.get("last_dsl"):
-            explanations.append(
-                "No previous query found for this session; unable to apply VPN filter."
-            )
+    if search_params is None:
+        if not GEMINI_API_KEY:
+            base_explain = " ".join(explanations).strip()
+            response: dict[str, Any] = {
+                "error": "No rule matched and GEMINI_API_KEY is not configured.",
+            }
+            if base_explain:
+                response["explain"] = base_explain
+            return response
 
-        if "failed login" in lowered_query or "suspicious login" in lowered_query:
-            filters.append({"term": {"event.action.keyword": "authentication_failure"}})
-            explanations.append(
-                "Applied authentication failure filter because the query mentioned failed or suspicious logins."
-            )
+        try:
+            translated_dsl, llm_explain = translate_with_gemini(user_query, mapping)
+        except Exception as exc:  # noqa: BLE001 - we want to surface translation errors
+            base_explain = " ".join(explanations).strip()
+            error_payload: dict[str, Any] = {
+                "error": f"Gemini translation failed: {exc}",
+            }
+            if base_explain:
+                error_payload["explain"] = base_explain
+            return error_payload
 
-        timeframe_filters, _, timeframe_explanation = _resolve_timeframe_filters(lowered_query)
-        if timeframe_filters:
-            filters.extend(timeframe_filters)
-            if timeframe_explanation:
-                explanations.append(timeframe_explanation)
+        search_params = translated_dsl
+        if llm_explain:
+            explanations.append(llm_explain)
 
-        if filters:
-            es_query: dict[str, Any] = {"bool": {"filter": filters}}
-        else:
-            es_query = {"match_all": {}}
-            explanations.append("No specific rule matched; returning the most recent documents.")
+    if not isinstance(search_params, dict):
+        return {"error": "Translated DSL must be an object."}
 
-        search_params = {
-            "index": "logs-*",
-            "size": 5,
-            "sort": [{"@timestamp": {"order": "desc"}}],
-            "query": es_query,
+    if "index" not in search_params:
+        search_params["index"] = "logs-*"
+
+    mapping_fields = _collect_mapping_fields(mapping)
+    missing_fields = _validate_dsl_fields(search_params, mapping_fields)
+    if missing_fields:
+        explain_text = " ".join(explanations).strip()
+        return {
+            "error": "Fields not found in mapping: "
+            + ", ".join(sorted(missing_fields)),
+            "dsl": search_params,
+            "explain": explain_text,
         }
 
     SESSION_CONTEXT[session_id]["last_dsl"] = deepcopy(search_params)
@@ -271,10 +570,12 @@ async def ask(request: AskRequest) -> dict[str, Any]:
     hits = response.get("hits", {}).get("hits", [])
     sources = [hit.get("_source", {}) for hit in hits]
 
+    explain_text = " ".join(explanations).strip()
+
     return {
         "dsl": search_params,
         "results": sources,
-        "explain": " ".join(explanations),
+        "explain": explain_text,
     }
 
 


### PR DESCRIPTION
## Summary
- integrate the Gemini Python SDK and load credentials from the environment for NL to DSL translations
- add helpers to format index mappings, call Gemini with example prompts, and validate DSL field usage
- update the `/ask` endpoint to favor existing rules, fall back to Gemini when needed, and require mapped fields before querying Elasticsearch

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d4212f3414832eb78c4aefe499da89